### PR TITLE
Add RSS feed for out-of-stock notifications

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,17 @@ func siteHandler(w http.ResponseWriter, r *http.Request) {
 	foxhttp.ServeOptimized(w, r, ".html", time.Unix(0, 0), []byte(html), false)
 }
 
+func feedHandler(w http.ResponseWriter, r *http.Request) {
+	feed, err := ui.RenderFeed()
+	if err != nil {
+		slog.Error("failed to render feed: " + err.Error())
+		http.Error(w, "failed to render feed", http.StatusInternalServerError)
+		return
+	}
+
+	foxhttp.ServeOptimized(w, r, ".xml", time.Unix(0, 0), []byte(feed), false)
+}
+
 func main() {
 	if config.IN_DEV {
 		slog.Warn("in development mode")
@@ -58,6 +69,7 @@ func main() {
 	data.Init()
 
 	http.HandleFunc("GET /{$}", siteHandler)
+	http.HandleFunc("GET /feed.xml", feedHandler)
 	http.HandleFunc("GET /api/blahaj", apiHandler)
 	http.HandleFunc("GET /notabot.gif", foxhttp.HandleNotABotGif(
 		func(r *http.Request) {

--- a/ui/feed.go
+++ b/ui/feed.go
@@ -1,0 +1,135 @@
+// feed.go - RSS feed for out-of-stock stores
+//
+// Purpose:
+//   1. See all out-of-stock stores at a glance
+//   2. Get notified whenever a new store runs out of stock
+//
+// Each store has a stable GUID (country + name + coordinates), so RSS readers
+// only notify on NEW out-of-stock events. Restocked stores disappear silently.
+// If a store goes out of stock again later, it triggers a new notification.
+
+package ui
+
+import (
+	"encoding/xml"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/makinori/blahaj-quest/config"
+	"github.com/makinori/blahaj-quest/data"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+type rssChannel struct {
+	XMLName       xml.Name  `xml:"channel"`
+	Title         string    `xml:"title"`
+	Link          string    `xml:"link"`
+	Description   string    `xml:"description"`
+	LastBuildDate string    `xml:"lastBuildDate"`
+	Items         []rssItem `xml:"item"`
+}
+
+type rssItem struct {
+	Title       string  `xml:"title"`
+	Link        string  `xml:"link"`
+	GUID        rssGUID `xml:"guid"`
+	Description string  `xml:"description"`
+}
+
+type rssGUID struct {
+	IsPermaLink bool   `xml:"isPermaLink,attr"`
+	Value       string `xml:",chardata"`
+}
+
+type rssFeed struct {
+	XMLName xml.Name   `xml:"rss"`
+	Version string     `xml:"version,attr"`
+	Channel rssChannel `xml:"channel"`
+}
+
+// slugify converts a store name to a URL-safe slug for use in GUIDs
+func slugify(s string) string {
+	// Normalize unicode (decompose accents)
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	result, _, _ := transform.String(t, s)
+
+	// Lowercase
+	result = strings.ToLower(result)
+
+	// Replace spaces and common separators with hyphens
+	result = strings.ReplaceAll(result, " ", "-")
+	result = strings.ReplaceAll(result, "_", "-")
+
+	// Remove any character that isn't alphanumeric or hyphen
+	reg := regexp.MustCompile(`[^a-z0-9-]`)
+	result = reg.ReplaceAllString(result, "")
+
+	// Collapse multiple hyphens
+	reg = regexp.MustCompile(`-+`)
+	result = reg.ReplaceAllString(result, "-")
+
+	// Trim leading/trailing hyphens
+	result = strings.Trim(result, "-")
+
+	return result
+}
+
+// RenderFeed generates an RSS feed of all out-of-stock stores
+func RenderFeed() (string, error) {
+	var items []rssItem
+
+	for _, store := range data.Blahaj.Current {
+		if store.Quantity > 0 {
+			continue
+		}
+
+		storeSlug := slugify(store.Name)
+		// Include lat/lng to ensure uniqueness for stores with same name
+		guid := "blahaj|" + store.CountryCode + "|" + storeSlug + "|" + store.Lat + "," + store.Lng + "|oos"
+
+		// Build Google Maps link
+		mapsLink := "https://www.google.com/maps?q=" + store.Lat + "," + store.Lng
+
+		// Build IKEA store page link
+		ikeaLink := "https://www.ikea.com/" + store.CountryCode + "/" + store.LanguageCode + "/stores/"
+
+		// Rich HTML description
+		description := `<p><strong>Blahaj is currently out of stock</strong> at IKEA ` + store.Name + `.</p>` +
+			`<p>` +
+			`<a href="` + mapsLink + `">View on Google Maps</a> · ` +
+			`<a href="` + ikeaLink + `">IKEA Store Page</a>` +
+			`</p>`
+
+		items = append(items, rssItem{
+			Title:       "IKEA " + store.Name + " (" + strings.ToUpper(store.CountryCode) + ") – Blahaj out of stock",
+			Link:        mapsLink,
+			Description: description,
+			GUID: rssGUID{
+				IsPermaLink: false,
+				Value:       guid,
+			},
+		})
+	}
+
+	feed := rssFeed{
+		Version: "2.0",
+		Channel: rssChannel{
+			Title:         "Blahaj Quest – Out of Stock Alerts",
+			Link:          config.URL,
+			Description:   "Get notified when IKEA stores run out of Blahaj",
+			LastBuildDate: time.Now().Format(time.RFC1123Z),
+			Items:         items,
+		},
+	}
+
+	output, err := xml.MarshalIndent(feed, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return xml.Header + string(output), nil
+}


### PR DESCRIPTION
## RSS Feed for Out-of-Stock Notifications

Adds `/feed.xml` - an RSS feed for tracking Blahaj availability.

### Why

1. **See all out-of-stock stores at a glance** - The feed lists every store currently without Blahaj
2. **Get notified when a new store runs out** - Subscribe in any RSS reader and get alerts for new out-of-stock events

### How it works

Each store has a stable GUID based on country, name, and coordinates:

```
blahaj|de|ikea-berlin|52.51,13.40|oos
```

This means:
- **New store out of stock** → New notification
- **Store already out of stock** → No notification (same GUID)
- **Store restocks** → Disappears from feed, no notification
- **Store goes out of stock again** → Notifies again

The feed is generated on each request, using stock data that's refreshed hourly from IKEA.

### Changes

- `ui/feed.go` - RSS generation
- `main.go` - `/feed.xml` endpoint