### PR TITLE
Add Estonia, Latvia, Lithuania

### DIFF
--- a/data/blahaj.go
+++ b/data/blahaj.go
@@ -35,7 +35,7 @@ type BlahajData []BlahajStore
 
 type IkeaStore struct {
 	ID   string `json:"id"`
-	Name string `json:"name"`
+	Name string `json:"displayNameAlternate"`
 	Lat  string `json:"lat"`
 	Lng  string `json:"lng"`
 }

--- a/data/blahajdb.go
+++ b/data/blahajdb.go
@@ -71,21 +71,11 @@ var BlahajDatabase = []blahajCountry{
 	// moldova has like fake ikea what
 	// bosnia and herzegovina
 	// albania
-	// lithuania has a different api
+	c("lt", "lt", "30373588"), // lithuania
 	c("si", "sl", "30373588"), // slovenia
 	// north macedonia has no ikea
-	// latvia has a different api
-	// c(
-	// 	"ee",
-	// 	"en",
-	// 	"30373588",
-	// 	IkeaStore{
-	// 		ID:   "648",
-	// 		Name: "IKEA Tallinn",
-	// 		Lat:  "59.338481",
-	// 		Lng:  "24.827531",
-	// 	},
-	// ), // estonia
+	c("lv", "lv", "30373588"), // latvia
+	c("ee", "et", "30373588"), // estonia
 	// luxembourg has no ikea yet, until 2025
 	// montenegro has another fake ikea
 	// malta


### PR DESCRIPTION
Adds Estonia, Latvia and Lithuania.

On the Ikea websites, `displayNameAlternate` is the name actually shown to the user. The `name` field seems to be something internal. Even though it closely matches up with the display names of most Ikea stores, this is not always the case, as seen in the Baltics.